### PR TITLE
refactor: move encoding/decoding logic into Codec

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -1,21 +1,40 @@
 package dedupe
 
-type Codec[T Repr] struct {
-	t table[T]
+// A codec can be used to convert a string into a a more compact representation.
+type Codec struct {
+	t    table[string]
+	repr ObjectRepr[string]
 }
 
-func NewCodec[T Repr](t table[T]) *Codec[T] {
+func NewCodec(t table[string], repr ObjectRepr[string]) *Codec {
 	// TODO: Use options pattern to configure the codec.
-	return &Codec[T]{t: t}
+	return &Codec{
+		t:    t,
+		repr: repr,
+	}
 }
 
 // Encode the provided value by obtaining a compact representation for it.
-func (c *Codec[T]) Encode(s string) T {
-	return c.t.StoreAsRepr(s)
+func (c *Codec) Encode(s string) string {
+	val, err := c.t.Lookup(s)
+	if err != nil {
+		// 1. Compute representation.
+		repr := c.repr.GetRepr(s)
+
+		// 2. Store representation in the table.
+		c.t.Store(s, repr)
+
+		// 3. Store the reverse mapping.
+		c.t.Store(repr, s)
+
+		// 3. Set val.
+		val = repr
+	}
+	return val
 }
 
 // Retrieve a value from its compact representation.
-func (c *Codec[T]) Decode(o T) string {
-	// TODO
-	return ""
+func (c *Codec) Decode(repr string) (string, error) {
+	val, err := c.t.Lookup(repr)
+	return val, err
 }

--- a/codec_test.go
+++ b/codec_test.go
@@ -1,0 +1,37 @@
+package dedupe
+
+import (
+	"testing"
+)
+
+func TestCodecEncode(t *testing.T) {
+	repr := NewDefaultObjectRepr()
+	table := NewRedisTable()
+	codec := NewCodec(table, repr)
+
+	for _, s := range testStrings {
+		r := codec.Encode(s)
+		if len(r) > len(s) {
+			t.Errorf("Encoded representation is not compact: %s %s", []byte(s), []byte(r))
+		}
+	}
+}
+
+func TestCodecDecode(t *testing.T) {
+	repr := NewDefaultObjectRepr()
+	table := NewRedisTable()
+	codec := NewCodec(table, repr)
+
+	for _, s := range testStrings {
+		r := codec.Encode(s)
+		o, err := codec.Decode(r)
+		if err != nil {
+			t.Errorf("Failed to decode representation: %s", err.Error())
+		}
+		if o != s {
+			t.Errorf("Decoded something other than the original string: %v %v",
+				[]byte(s),
+				[]byte(o))
+		}
+	}
+}

--- a/redis_table.go
+++ b/redis_table.go
@@ -2,23 +2,19 @@ package dedupe
 
 import (
 	"context"
-	"errors"
-	"fmt"
 
 	"github.com/redis/go-redis/v9"
 )
 
 // A table that uses Redis as a backend store.
 type redisTable struct {
-	repr   ObjectRepr[string]
 	client *redis.Client
 	ctx    context.Context
 }
 
 // Create a new Redis backed table.
-func NewRedisTable(repr ObjectRepr[string]) *redisTable {
+func NewRedisTable() *redisTable {
 	return &redisTable{
-		repr: repr,
 		client: redis.NewClient(&redis.Options{
 			// TODO: Get from enviroment variable.
 			// TODO: Look into how go services are normally configured.
@@ -28,36 +24,17 @@ func NewRedisTable(repr ObjectRepr[string]) *redisTable {
 	}
 }
 
-func (rt *redisTable) StoreAsRepr(s string) string {
+func (rt *redisTable) Lookup(s string) (string, error) {
 	val, err := rt.client.Get(rt.ctx, s).Result()
 	if err != nil {
-		// 1. Compute representation.
-		repr := rt.repr.GetRepr(s)
-
-		// 2. Store representation in Redis.
-		status := rt.client.Set(rt.ctx, s, repr, 0)
-		if status.Err() != nil {
-			panic("Failed to set value in Redis: " + status.Err().Error())
-		}
-
-		status = rt.client.Set(rt.ctx, repr, s, 0)
-		if status.Err() != nil {
-			panic("Failed to set value in Redis: " + status.Err().Error())
-		}
-
-		// 3. Set val.
-		val = repr
+		return "", err
 	}
-
-	return val
+	return val, nil
 }
 
-func (rt *redisTable) RecoverFromRepr(repr string) (string, error) {
-	val, err := rt.client.Get(rt.ctx, repr).Result()
-	if err != nil {
-		return "", errors.New(fmt.Sprintf(
-			"Could not find representation: %v: %s", []byte(repr), err.Error()))
+func (rt *redisTable) Store(s string, repr string) {
+	status := rt.client.Set(rt.ctx, s, repr, 0)
+	if status.Err() != nil {
+		panic("Failed to set value in Redis: " + status.Err().Error())
 	}
-
-	return val, nil
 }

--- a/redis_table_test.go
+++ b/redis_table_test.go
@@ -4,42 +4,12 @@ import (
 	"testing"
 )
 
-var (
-	repr = NewDefaultObjectRepr()
-)
-
 func TestConformsToInterface(t *testing.T) {
 	var table table[string]
-	table = NewRedisTable(repr)
+	table = NewRedisTable()
 	_ = table
 }
 
-func TestRedisStoreAsRepr(t *testing.T) {
-	table := NewRedisTable(repr)
+// TODO: Test store
 
-	for _, s := range testStrings {
-		r := table.StoreAsRepr(s)
-		if len(r) > len(s) {
-			t.Errorf("Lookup returned a representation that is thiccer than the original string: %s | %s",
-				s,
-				r)
-		}
-	}
-}
-
-func TestRedisRecoverFromRepr(t *testing.T) {
-	table := NewRedisTable(repr)
-
-	for _, s := range testStrings {
-		r := table.StoreAsRepr(s)
-		o, err := table.RecoverFromRepr(r)
-		if err != nil {
-			t.Errorf("Failed to recover representation: %s", err.Error())
-		}
-		if o != s {
-			t.Errorf("Recovered something other than the original string: %v %v",
-				[]byte(s),
-				[]byte(o))
-		}
-	}
-}
+// TODO: Test lookup

--- a/repr.go
+++ b/repr.go
@@ -26,7 +26,7 @@ func (r *simpleObjectRepr) GetRepr(s string) string {
 	count := r.counter
 	r.counter += 1
 
-	repr := fmt.Sprintf("\x00%s", strconv.Itoa(count))
+	repr := fmt.Sprintf("%s", strconv.Itoa(count))
 
 	if len(repr) > len(s) {
 		return s

--- a/table.go
+++ b/table.go
@@ -1,9 +1,8 @@
 package dedupe
 
 type table[T Repr] interface {
-	// This methods finds an appropriate representation for the string s and returns it.
-	StoreAsRepr(s string) T
-
-	// Recovers the original object from its representation.
-	RecoverFromRepr(repr T) (string, error)
+	// Store a value in the table.
+	Store(s string, repr T)
+	// Try to retrieve a value from the table.
+	Lookup(s string) (T, error)
 }


### PR DESCRIPTION
This makes it so that the table implementation can be just a dictionary and easily replaced.